### PR TITLE
feat: add multitenancy support with tenant-based topic validation

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -31,7 +31,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/feat/multitenancy-support' }}
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -47,10 +47,18 @@ jobs:
 
       - name: package soteria helm chart
         run: |
-          version=${{ github.ref_name }}
-          helm package --version "${version##v}" --app-version "${version}" ./charts/soteria
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            version=${{ github.ref_name }}
+            helm package --version "${version##v}" --app-version "${version}" ./charts/soteria
+          else
+            helm package --version "0.0.0-multitenancy" --app-version "multitenancy" ./charts/soteria
+          fi
 
       - name: publish soteria chart to github container registry
         run: |
-          version=${{ github.ref_name }}
-          helm push "soteria-${version##v}".tgz oci://ghcr.io/snapp-incubator/soteria-chart
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            version=${{ github.ref_name }}
+            helm push "soteria-${version##v}.tgz" oci://ghcr.io/snapp-incubator/soteria-chart
+          else
+            helm push "soteria-0.0.0-multitenancy.tgz" oci://ghcr.io/snapp-incubator/soteria-chart
+          fi

--- a/internal/authenticator/auto_authenticator_test.go
+++ b/internal/authenticator/auto_authenticator_test.go
@@ -150,6 +150,7 @@ func TestAutoAuthenticator_ValidateTopicBySender(t *testing.T) {
 	})
 }
 
+// nolint: funlen
 func TestAutoAuthenticator_TenantValidation(t *testing.T) {
 	t.Parallel()
 
@@ -158,14 +159,16 @@ func TestAutoAuthenticator_TenantValidation(t *testing.T) {
 	hid, err := topics.NewHashIDManager(cfg.HashIDMap)
 	require.NoError(t, err)
 
+	// nolint: exhaustruct
 	auth := authenticator.AutoAuthenticator{
 		AllowedAccessTypes: []acl.AccessType{acl.Pub, acl.Sub},
 		Company:            "snapp",
 		Parser:             jwt.NewParser(),
 		TopicManager:       topics.NewTopicManager(cfg.Topics, hid, "snapp", cfg.IssEntityMap, cfg.IssPeerMap, zap.NewNop()),
 		JWTConfig: config.JWT{
-			IssName: "iss",
-			SubName: "sub",
+			IssName:       "iss",
+			SubName:       "sub",
+			SigningMethod: "RS256",
 		},
 	}
 

--- a/internal/authenticator/auto_authenticator_test.go
+++ b/internal/authenticator/auto_authenticator_test.go
@@ -149,3 +149,70 @@ func TestAutoAuthenticator_ValidateTopicBySender(t *testing.T) {
 		require.NotNil(t, topicTemplate)
 	})
 }
+
+func TestAutoAuthenticator_TenantValidation(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.SnappVendor()
+
+	hid, err := topics.NewHashIDManager(cfg.HashIDMap)
+	require.NoError(t, err)
+
+	auth := authenticator.AutoAuthenticator{
+		AllowedAccessTypes: []acl.AccessType{acl.Pub, acl.Sub},
+		Company:            "snapp",
+		Parser:             jwt.NewParser(),
+		TopicManager:       topics.NewTopicManager(cfg.Topics, hid, "snapp", cfg.IssEntityMap, cfg.IssPeerMap, zap.NewNop()),
+		JWTConfig: config.JWT{
+			IssName: "iss",
+			SubName: "sub",
+		},
+	}
+
+	t.Run("tenant matches topic prefix", func(t *testing.T) {
+		t.Parallel()
+
+		claims := jwt.MapClaims{
+			"iss":       "0",
+			"sub":       "123",
+			"tenant_id": "snapp-ir",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+		tokenString, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+
+		ok, err := auth.ACL(context.Background(), acl.Pub, tokenString, "snapp-ir/driver/123/location")
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("tenant does not match topic prefix", func(t *testing.T) {
+		t.Parallel()
+
+		claims := jwt.MapClaims{
+			"iss":       "0",
+			"sub":       "123",
+			"tenant_id": "snapp-ir",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+		tokenString, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+
+		ok, err := auth.ACL(context.Background(), acl.Pub, tokenString, "baly-iq/driver/123/location")
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("no tenant falls back to regex validation", func(t *testing.T) {
+		t.Parallel()
+
+		claims := jwt.MapClaims{
+			"iss": "0",
+			"sub": "DXKgaNQa7N5Y7bo",
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+		tokenString, _ := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+
+		ok, err := auth.ACL(context.Background(), acl.Pub, tokenString, validDriverLocationTopic)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+}

--- a/internal/authenticator/manual_authenticator.go
+++ b/internal/authenticator/manual_authenticator.go
@@ -109,6 +109,15 @@ func (a ManualAuthenticator) ACL(
 
 	sub := strconv.ToString(claims[a.JWTConfig.SubName])
 
+	matched, err := validateTopicByTenant(topic, claims)
+	if err != nil {
+		return false, err
+	}
+
+	if matched {
+		return true, nil
+	}
+
 	topicTemplate := a.TopicManager.ParseTopic(topic, issuer, sub, map[string]any(claims))
 	if topicTemplate == nil {
 		return false, InvalidTopicError{Topic: topic}


### PR DESCRIPTION
- Extract tenant_id from JWT claims for topic validation
- If tenant_id exists, validate topic prefix matches tenant
- Fall back to regex validation when no tenant_id in claims
- Add reusable validateTopicByTenant function
- Add tests for tenant validation
- Update helm workflow to release from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)